### PR TITLE
Add nginx server block

### DIFF
--- a/nginx/bot.conf
+++ b/nginx/bot.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name bot.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add a sample nginx server block for `bot.example.com`

## Testing
- `python -m py_compile db.py web/api.py bot/main.py bot/storage.py bot/keyboards.py bot/handlers/location.py`

------
https://chatgpt.com/codex/tasks/task_e_68626ede93c0832aa62f3f8edd15595b