### PR TITLE
Add onboarding message in /start handler

### DIFF
--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -1,13 +1,23 @@
 import logging
 
-from aiogram.types import Message
+from aiogram.types import Message, ReplyKeyboardMarkup
 
 from ..keyboards import location_kb
 
 logger = logging.getLogger(__name__)
 
 
-async def start(message: Message) -> None:
+async def start(message: Message) -> ReplyKeyboardMarkup:
     """Handle /start command."""
     logger.info("User %s started bot", message.from_user.id if message.from_user else "unknown")
-    await message.answer("Please share your location", reply_markup=location_kb())
+    keyboard = location_kb()
+    await message.answer("Please share your location", reply_markup=keyboard)
+    await message.answer(
+        "Компания <b>Технологистика</b> желает вам счастливого пути!\n"
+        "• Нажимайте «<Поделиться местоположением>» <u>каждые 24 ч</u>,\n"
+        "  чтобы мы знали, где находится автомобиль.\n"
+        "• Не переживайте, если забудете — бот сам напомнит.\n"
+        "• Live-локация передаётся автоматически каждый час.",
+        parse_mode="HTML",
+    )
+    return keyboard


### PR DESCRIPTION
## Summary
- modify `/start` handler to send second HTML-formatted message
- return the reply keyboard for re-use

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627b17e68c832a9505b046150e7927