### PR TITLE
Add periodic location reminders

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -10,7 +10,6 @@ import db
 from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.filters import CommandStart
-from aiogram.types import Message
 from dotenv import load_dotenv
 
 from .handlers.start import start
@@ -27,8 +26,40 @@ logger = logging.getLogger(__name__)
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 
-async def check_stale(bot: Bot) -> None:
-    """Periodically remind users to extend live location."""
+async def remind_once_a_day(bot: Bot) -> None:
+    """Send a daily reminder if a user didn't share a point in the last 24 h."""
+    query = (
+        "SELECT user_id, MAX(strftime('%s', ts)) as last_ts "
+        "FROM points "
+        "GROUP BY user_id "
+        "HAVING last_ts < strftime('%s', 'now') - 24*3600"
+    )
+    while True:
+        try:
+            async with aiosqlite.connect(db.DB_PATH) as conn:
+                await db._ensure_schema(conn)
+                async with conn.execute(query) as cur:
+                    rows = await cur.fetchall()
+                    user_ids = [row[0] for row in rows]
+        except Exception:
+            logger.exception("Failed to fetch users for daily reminder")
+            await asyncio.sleep(30 * 60)
+            continue
+
+        for uid in user_ids:
+            try:
+                await bot.send_message(
+                    uid,
+                    "Напоминание! Пожалуйста, нажмите “Поделиться местоположением”.",
+                )
+            except Exception:
+                logger.exception("Failed to send daily reminder to %s", uid)
+
+        await asyncio.sleep(30 * 60)
+
+
+async def alert_if_stale_live(bot: Bot) -> None:
+    """Remind users to extend Telegram Live Location when it expired."""
     while True:
         try:
             async with aiosqlite.connect(db.DB_PATH) as conn:
@@ -68,7 +99,8 @@ async def main() -> None:
     dp.message.register(start, CommandStart())
     dp.message.register(location, lambda m: m.location is not None)
 
-    asyncio.create_task(check_stale(bot))
+    asyncio.create_task(remind_once_a_day(bot))
+    asyncio.create_task(alert_if_stale_live(bot))
 
     logger.info("Starting polling")
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- send daily reminder with `remind_once_a_day`
- keep previous stale live location reminder as `alert_if_stale_live`
- launch both tasks when the bot starts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68627bb22ab0832a9eaea2b7b84dda28