### PR TITLE
Add contact button

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -3,8 +3,9 @@ from aiogram.utils.keyboard import ReplyKeyboardBuilder
 
 
 def location_kb() -> ReplyKeyboardMarkup:
-    """Keyboard with a single button requesting location."""
+    """Keyboard with contact and location buttons."""
     builder = ReplyKeyboardBuilder()
+    builder.button(text="Поделиться номером", request_contact=True)
     builder.button(text="Поделиться местоположением", request_location=True)
-    builder.adjust(1)
+    builder.adjust(1, 1)
     return builder.as_markup(resize_keyboard=True, one_time_keyboard=False)


### PR DESCRIPTION
## Summary
- extend location keyboard with a 'share contact' button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862df9fd7ec832aa1cca97c676bcc79