### PR TITLE
Add drivers table with phone storage

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -95,6 +95,8 @@ async def main() -> None:
     if not BOT_TOKEN:
         raise RuntimeError("BOT_TOKEN is not set")
 
+    await db.init()
+
     bot = Bot(BOT_TOKEN)
     dp = Dispatcher(storage=MemoryStorage())
 

--- a/web/api.py
+++ b/web/api.py
@@ -2,9 +2,14 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from db import get_last_point
+from db import get_last_point, init
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    await init()
 
 templates = Jinja2Templates(directory="templates")
 


### PR DESCRIPTION
## Summary
- add driver DB migrations and init
- store driver phone numbers
- initialize DB at bot and web startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862e10e8a28832abe02a58d102ea9ce